### PR TITLE
feat: fix duplicate command error

### DIFF
--- a/src/UnityBuildRunner/Program.cs
+++ b/src/UnityBuildRunner/Program.cs
@@ -14,102 +14,40 @@ builder.ConfigureServices((hostContext, services) =>
 });
 
 var app = builder.Build();
-app.AddCommands<UnityBuildRunnerBatch>();
+app.AddCommands<UnityBuildRunnerCommand>();
 app.Run();
 
-public class UnityBuildRunnerBatch : ConsoleAppBase
+public class UnityBuildRunnerCommand : ConsoleAppBase
 {
     private const string defaultTimeout = "00:60:00";
 
     private readonly IBuilder builder;
     private readonly ISettings settings;
 
-    public UnityBuildRunnerBatch(IBuilder builder, ISettings settings)
+    public UnityBuildRunnerCommand(IBuilder builder, ISettings settings)
     {
         this.builder = builder;
         this.settings = settings;
     }
 
-    public async Task RunWithoutUnityPath([Option("-t")] string timeout = defaultTimeout)
+    [RootCommand]
+    public async Task Full([Option("-u", "Full Path to the Unity.exe")] string unityPath = "", [Option("-t")] string timeout = defaultTimeout)
     {
         var args = Context.Arguments
-            .Except(new[] { "-timeout", "-t", timeout })
-            .ToArray();
-        settings.Parse(args, "");
-        var timeoutSpan = TimeSpan.TryParse(timeout, out var r) ? r : TimeSpan.FromMinutes(60);
-        if (string.IsNullOrWhiteSpace(settings.LogFilePath) || string.IsNullOrWhiteSpace(settings.ArgumentString))
+            .Except(new[] { "-timeout", "-t", timeout });
+        if (!string.IsNullOrEmpty(unityPath))
         {
-            Help();
-            return;
+            args = args.Except(new[] { "-UnityPath", "-unityPath", "-u", unityPath });
         }
-
-        Context.Logger.LogInformation("Unity Build Begin.");
-        try
-        {
-            var result = await builder.BuildAsync(settings, timeoutSpan);
-            Environment.ExitCode = result;
-        }
-        catch (Exception)
-        {
-            Help();
-            Environment.ExitCode = 1;
-        }
-    }
-
-    [Command(new[] { "-UnityPath", "-unityPath", "-u" })]
-    public async Task RunWithUnityPath([Option(0, "Full Path to the Unity.exe")] string unityPath, [Option("-t")] string timeout = defaultTimeout)
-    {
-        var args = Context.Arguments
-            .Except(new[] { "-UnityPath", "-unityPath", "-u", unityPath })
-            .Except(new[] { "-timeout", "-t", timeout })
-            .ToArray();
-        settings.Parse(args, unityPath);
+        settings.Parse(args.ToArray(), unityPath);
         var timeoutSpan = TimeSpan.TryParse(timeout, out var r) ? r : TimeSpan.FromMinutes(60);
 
         if (string.IsNullOrWhiteSpace(settings.LogFilePath) || string.IsNullOrWhiteSpace(settings.ArgumentString))
         {
-            Help();
-            return;
+            throw new ArgumentNullException("Missing '-log' argument. Please add '-log log.log' or any log path.");
         }
 
         Context.Logger.LogInformation("Unity Build Begin.");
-        try
-        {
-            var result = await builder.BuildAsync(settings, timeoutSpan);
-            Environment.ExitCode = result;
-        }
-        catch (Exception)
-        {
-            Environment.ExitCode = 1;
-        }
-    }
-
-    /// <summary>
-    /// Provide unix style command argument: -version --version -v + version command
-    /// </summary>
-    [Command(new[] { "version", "-v", "-version", "--version" }, "show version")]
-    public void Version()
-    {
-        var version = Assembly.GetEntryAssembly()
-            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
-            .InformationalVersion
-            .ToString();
-        Context.Logger.LogInformation($"UnityBuildRunner v{version}");
-    }
-
-    /// <summary>
-    /// Provide unix style command argument: -help --help -h + override default help / list
-    /// </summary>
-    /// <remarks>
-    /// Also override default help. no arguments execution will fallback to here.
-    /// </remarks>
-    [Command(new[] { "help", "list", "-h", "-help", "--help" }, "show help")]
-    public void Help()
-    {
-        Context.Logger.LogInformation($"Usage: UnityBuildRunner [-UnityPath|-unityPath|-u] [-timeout|-t {defaultTimeout}] [-version] [-help] [args]");
-        Context.Logger.LogInformation("If you omit -logFile xxxx.log, default LogFilePath '-logFile unitybuild.log' will be use.");
-        Context.Logger.LogInformation(@"E.g., run this: UnityBuildRunner -u UNITYPATH -quit -batchmode -buildTarget WindowsStoreApps -projectPath HOLOLENS_UNITYPROJECTPATH -executeMethod HoloToolkit.Unity.HoloToolkitCommands.BuildSLN");
-        Context.Logger.LogInformation(@"E.g., run this: UnityBuildRunner -u UNITYPATH -quit -batchmode -buildTarget WindowsStoreApps -projectPath HOLOLENS_UNITYPROJECTPATH -logfile log.log -executeMethod HoloToolkit.Unity.HoloToolkitCommands.BuildSLN");
-        Context.Logger.LogInformation(@"E.g., set UnityPath as EnvironmentVariable `UnityPath` & run this: UnityBuildRunner -quit -batchmode -buildTarget WindowsStoreApps -projectPath HOLOLENS_UNITYPROJECTPATH -logfile log.log -executeMethod HoloToolkit.Unity.HoloToolkitCommands.BuildSLN");
+        await builder.BuildAsync(settings, timeoutSpan);
     }
 }

--- a/src/UnityBuildRunner/Properties/launchSettings.json
+++ b/src/UnityBuildRunner/Properties/launchSettings.json
@@ -2,9 +2,13 @@
   "profiles": {
     "UnityBuildRunner": {
       "commandName": "Project",
-      "commandLineArgs": "-u \"C:\\Program Files\\Unity\\Hub\\Editor\\2018.3.13f1\\Editor\\Unity.exe\" -quit -batchmode -buildTarget WindowsStoreApps -projectPath D:\\git\\guitarrapc\\HoloLens-AzurePipelinev1 -logfile log.log -executeMethod HoloToolkit.Unity.HoloToolkitCommands.BuildSLN",
+      "commandLineArgs": ""
+    },
+    "UnityBuildRunner (unity)": {
+      "commandName": "Project",
+      "commandLineArgs": "-quit -batchmode -nographics -silent-crashes -logfile log.log -buildTarget StandaloneWindows64 /headless /ScriptBackend mono -projectPath C:/git/cysharp/MemoryPack/src/MemoryPack.Unity -executeMethod UnitTestBuilder.BuildUnitTest",
       "environmentVariables": {
-        "UnityPath": "C:\\Program Files\\Unity\\Hub\\Editor\\2018.3.13f1\\Editor\\Unity.exe"
+        "UnityPath": "C:\\Program Files\\Unity\\Hub\\Editor\\2021.3.11f1\\Editor\\Unity.exe"
       }
     }
   }

--- a/src/UnityBuildRunner/Properties/launchSettings.json
+++ b/src/UnityBuildRunner/Properties/launchSettings.json
@@ -6,7 +6,7 @@
     },
     "UnityBuildRunner (unity-path)": {
       "commandName": "Project",
-      "commandLineArgs": "--unity-path \"C:\\Program Files\\Unity\\Hub\\Editor\\2021.3.11f1\\Editor\\Unity.exe\" -quit -batchmode -nographics -silent-crashes -logfile log.log -buildTarget StandaloneWindows64 /headless /ScriptBackend mono -projectPath C:/git/cysharp/MemoryPack/src/MemoryPack.Unity -executeMethod UnitTestBuilder.BuildUnitTest",
+      "commandLineArgs": "--unity-path \"C:\\Program Files\\Unity\\Hub\\Editor\\2021.3.11f1\\Editor\\Unity.exe\" -quit -batchmode -nographics -silent-crashes -logfile log.log -buildTarget StandaloneWindows64 /headless /ScriptBackend mono -projectPath C:/git/cysharp/MemoryPack/src/MemoryPack.Unity -executeMethod UnitTestBuilder.BuildUnitTest"
     },
     "UnityBuildRunner (env)": {
       "commandName": "Project",

--- a/src/UnityBuildRunner/Properties/launchSettings.json
+++ b/src/UnityBuildRunner/Properties/launchSettings.json
@@ -4,7 +4,11 @@
       "commandName": "Project",
       "commandLineArgs": ""
     },
-    "UnityBuildRunner (unity)": {
+    "UnityBuildRunner (unity-path)": {
+      "commandName": "Project",
+      "commandLineArgs": "--unity-path \"C:\\Program Files\\Unity\\Hub\\Editor\\2021.3.11f1\\Editor\\Unity.exe\" -quit -batchmode -nographics -silent-crashes -logfile log.log -buildTarget StandaloneWindows64 /headless /ScriptBackend mono -projectPath C:/git/cysharp/MemoryPack/src/MemoryPack.Unity -executeMethod UnitTestBuilder.BuildUnitTest",
+    },
+    "UnityBuildRunner (env)": {
       "commandName": "Project",
       "commandLineArgs": "-quit -batchmode -nographics -silent-crashes -logfile log.log -buildTarget StandaloneWindows64 /headless /ScriptBackend mono -projectPath C:/git/cysharp/MemoryPack/src/MemoryPack.Unity -executeMethod UnitTestBuilder.BuildUnitTest",
       "environmentVariables": {

--- a/src/UnityBuildRunner/UnityBuildRunner.csproj
+++ b/src/UnityBuildRunner/UnityBuildRunner.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
 
     <Version>1.0.0</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>


### PR DESCRIPTION
## tl;dr;

fix error on launch.

```
> dotnet UnityBuildRunner.dll

Unhandled exception. System.InvalidOperationException: Duplicate command name is added. Name:-unityPath Method:UnityBuildRunnerBatch.RunWithUnityPath
   at ConsoleAppFramework.CommandDescriptorCollection.AddCommand(CommandDescriptor commandDescriptor)
   at ConsoleAppFramework.ConsoleApp.AddCommands[T]()
   at Program.<Main>$(String[] args) in /home/runner/work/UnityBuildRunner/UnityBuildRunner/src/UnityBuildRunner/Program.cs:line 10
```