### PR TITLE
fix: use short name instead of index

### DIFF
--- a/src/UnityBuildRunner/Program.cs
+++ b/src/UnityBuildRunner/Program.cs
@@ -36,7 +36,7 @@ public class UnityBuildRunnerCommand : ConsoleAppBase
             .Except(new[] { "--timeout", "-t", timeout });
         if (!string.IsNullOrEmpty(unityPath))
         {
-            arguments = arguments.Except(new[] { "--unity-path", "-u", unityPath });
+            arguments = arguments.Except(new[] { "--unity-path", unityPath });
         }
 
         if (arguments is not null && arguments.Any())

--- a/src/UnityBuildRunner/Program.cs
+++ b/src/UnityBuildRunner/Program.cs
@@ -30,7 +30,7 @@ public class UnityBuildRunnerCommand : ConsoleAppBase
     }
 
     [RootCommand]
-    public async Task<int> Full([Option(0, "Full Path to the Unity.exe (Can use 'UnityPath' Environment variables instead.)")] string unityPath = "", [Option(1, $"Timeout to terminate execution within. default: \"{defaultTimeout}\"")] string timeout = defaultTimeout)
+    public async Task<int> Full([Option("--unity-path", "Full Path to the Unity.exe (Can use 'UnityPath' Environment variables instead.)")] string unityPath = "", [Option("--timeout", $"Timeout to terminate execution within. default: \"{defaultTimeout}\"")] string timeout = defaultTimeout)
     {
         var arguments = Context.Arguments
             .Except(new[] { "--timeout", "-t", timeout });


### PR DESCRIPTION
## tl;dr;

2.1.0 introduce parameter to use index, but revert back to short name.