### PR TITLE
fix:  treat `-logFile -` as invalid and replace to default log filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ await builder.BuildAsync(cts.Token);
 Console.WriteLine(builder.ExitCode);
 ```
 
-# TODO
+## FAQ
 
-- [x] dotnet global command
-- [x] core logic as nuget
+**What happen when passing `-logFile -` argument?**
+
+Unity.exe not generate log file when passing `-` as log file name. Therefore UnityBuildRunner replace `-` to temporary log file `unitybuild.log` instead.

--- a/src/UnityBuildRunner.Core/BuildErrorCode.cs
+++ b/src/UnityBuildRunner.Core/BuildErrorCode.cs
@@ -19,6 +19,8 @@ internal enum BuildErrorCode
     ProcessTimeout,
     [ErrorExitCode(9904)]
     OperationCancelled,
+    [ErrorExitCode(9905)]
+    LogFileNotFound,
     [ErrorExitCode(9999)]
     OtherError,
 }

--- a/src/UnityBuildRunner.Core/BuildErrorFoundException.cs
+++ b/src/UnityBuildRunner.Core/BuildErrorFoundException.cs
@@ -17,3 +17,18 @@ internal class BuildErrorFoundException : Exception
         MatchPattern = matchPattern;
     }
 }
+
+
+internal class BuildLogNotFoundException : Exception
+{
+    public override string Message => message;
+    private string message;
+
+    public string LogFilePath { get; }
+
+    public BuildLogNotFoundException(string message, string logFilePath)
+    {
+        this.message = message;
+        LogFilePath = logFilePath;
+    }
+}

--- a/src/UnityBuildRunner.Core/BuildErrorFoundException.cs
+++ b/src/UnityBuildRunner.Core/BuildErrorFoundException.cs
@@ -25,10 +25,12 @@ internal class BuildLogNotFoundException : Exception
     private string message;
 
     public string LogFilePath { get; }
+    public string FullPath { get; }
 
-    public BuildLogNotFoundException(string message, string logFilePath)
+    public BuildLogNotFoundException(string message, string logFilePath, string fullPath)
     {
         this.message = message;
         LogFilePath = logFilePath;
+        FullPath = fullPath;
     }
 }

--- a/src/UnityBuildRunner.Core/DefaultBuilder.cs
+++ b/src/UnityBuildRunner.Core/DefaultBuilder.cs
@@ -84,7 +84,7 @@ public class DefaultBuilder : IBuilder
                 if (logFileFound) break;
 
                 // retry for 10 seconds.
-                if (sw.Elapsed.TotalSeconds < 10 * 1000)
+                if (sw.Elapsed.TotalSeconds < 10)
                 {
                     await Task.Delay(TimeSpan.FromMilliseconds(10), ct).ConfigureAwait(false);
                 }

--- a/src/UnityBuildRunner.Core/DefaultBuilder.cs
+++ b/src/UnityBuildRunner.Core/DefaultBuilder.cs
@@ -90,7 +90,7 @@ public class DefaultBuilder : IBuilder
                 }
                 else
                 {
-                    throw new BuildLogNotFoundException($"Unity Process seems not create logfile.", settings.LogFilePath);
+                    throw new BuildLogNotFoundException($"Unity Process not created logfile.", settings.LogFilePath, Path.Combine(settings.WorkingDirectory, settings.LogFilePath));
                 }
             }
 
@@ -153,7 +153,7 @@ public class DefaultBuilder : IBuilder
         }
         catch (BuildLogNotFoundException ex)
         {
-            logger.LogCritical(ex, $"Stopping build.{ex.Message} logFile: '{ex.LogFilePath}'.");
+            logger.LogCritical(ex, $"Stopping build. {ex.Message} logFile: '{ex.LogFilePath}', FullPath: '{ex.FullPath}'.");
             buildErrorCode = BuildErrorCode.LogFileNotFound;
         }
         catch (Exception ex)

--- a/src/UnityBuildRunner.Core/DefaultBuilder.cs
+++ b/src/UnityBuildRunner.Core/DefaultBuilder.cs
@@ -79,17 +79,19 @@ public class DefaultBuilder : IBuilder
         try
         {
             // wait for log file generated.
-            while (!File.Exists(settings.LogFilePath) && !process.HasExited)
+            while (!process.HasExited)
             {
-                // retry in 10 seconds.
+                logFileFound = File.Exists(settings.LogFilePath);
+                if (logFileFound) break;
+
+                // retry for 10 seconds.
                 if (sw.Elapsed.TotalSeconds < 10 * 1000)
                 {
                     await Task.Delay(TimeSpan.FromMilliseconds(10), ct).ConfigureAwait(false);
                 }
                 else
                 {
-                    buildErrorCode = BuildErrorCode.ProcessTimeout;
-                    throw new TimeoutException($"Unity Process has been aborted. Waited 10 seconds but could't create logFilePath '{settings.LogFilePath}'.");
+                    throw new BuildLogNotFoundException($"Unity Process seems not create logfile.", settings.LogFilePath);
                 }
             }
 

--- a/src/UnityBuildRunner/Properties/launchSettings.json
+++ b/src/UnityBuildRunner/Properties/launchSettings.json
@@ -14,6 +14,10 @@
       "environmentVariables": {
         "UnityPath": "C:\\Program Files\\Unity\\Hub\\Editor\\2021.3.17f1\\Editor\\Unity.exe"
       }
+    },
+    "UnityBuildRunner (-logFile -)": {
+      "commandName": "Project",
+      "commandLineArgs": "--unity-path \"C:/Program Files/Unity/Hub/Editor/2021.3.17f1/Editor/Unity.exe\" -quit -batchmode -nographics -silent-crashes -logfile - -buildTarget StandaloneWindows64 -projectPath ../../../../../sandbox/Sandbox.Unity -executeMethod BuildUnity.BuildGame"
     }
   }
 }

--- a/tests/UnityBuildRunner.Core.Tests/SettingsUnitTests.cs
+++ b/tests/UnityBuildRunner.Core.Tests/SettingsUnitTests.cs
@@ -101,4 +101,15 @@ public class DefaultSettingsTest : IDisposable
         ISettings settings = DefaultSettings.Parse(actual, _unityPath, _timeout);
         settings.ArgumentString.Should().Be(expected);
     }
+
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    [InlineData("-", false)]
+    [InlineData("foo", true)]
+    [InlineData("log.log", true)]
+    public void IsValidLogFilePath(string? logFilePath, bool expected)
+    {
+        DefaultSettings.IsValidLogFileName(logFilePath).Should().Be(expected);
+    }
 }


### PR DESCRIPTION
## tl;dr;

fix when passing `-logFile -` unity cli argument, UnityBuildRunner could not find logfile and operation terminated.

This is due to 