### PR TITLE
feat: expand default timeout from 1hour to 2hour

### DIFF
--- a/src/UnityBuildRunner/Program.cs
+++ b/src/UnityBuildRunner/Program.cs
@@ -11,7 +11,7 @@ app.Run();
 
 public class UnityBuildRunnerCommand : ConsoleAppBase
 {
-    private const string DefaultTimeout = "01:00:00";
+    private const string DefaultTimeout = "02:00:00"; // 2 hours
 
     private readonly ILogger<UnityBuildRunnerCommand> logger;
     private readonly TimeSpan timeoutDefault;


### PR DESCRIPTION
## tl;dr;

Default timeout may be too short? Expand default may be not an severe change, let's change it to 2hour.